### PR TITLE
File upload support

### DIFF
--- a/model.js
+++ b/model.js
@@ -14,6 +14,7 @@ function builder(schema, opt) {
 
     // sync function for CRUD
     var sync = opt.sync;
+    var form_field = opt.form_field;
 
     var id_param = opt.id || 'id';
 
@@ -259,10 +260,12 @@ function builder(schema, opt) {
 
         cb = cb || function() {};
 
+        var body = (form_field && self[form_field]) || self;
+
         var sync_opt = {
             url: self.url,
             method: 'PUT',
-            body: self
+            body: body
         };
 
         var is_new = self.is_new();


### PR DESCRIPTION
In conjunction with the [bamboo-sync-ajax PR](https://github.com/defunctzombie/bamboo-sync-ajax/pull/2), this change allows one-way file uploads on a model by recognizing a special `form_data` field. This field is intended to be an HTML5 `FormData` object. If present, it is used as the request payload instead of the model's other fields. This allows multipart data to be sent to the server for things like file uploads. Or, a save of a model's attributes directly from a form instead of setting its properties explicitly:

Dommit example:

``` html
<form on-submit="on_submit">
    <!-- fields here -->
</form>
```

``` javascript
var Model = require('bamboo/model');
var ajax = require('bamboo-sync-ajax');

var SomeBambooModel = Model({
    status: String,
    reason: String,
    form_data: FormData // Only used one-way, for saving
}, {
    url_root: '/some-bamboo-model',
    sync: ajax,
    form_field: 'form_data'
});

module.exports = SomeBambooModel;
```

``` javascript
MyView.prototype.on_submit = function(ev, reactive) {
    var form = ev.target;
    var form_data = new FormData(form);
    var my_model = SomeBambooModel();
    my_model.form_data = form_data;
    my_model.save(function(err) {
        // Fields from the form above have been sent
    });
};
```
